### PR TITLE
Fix zero price rule creation

### DIFF
--- a/Diarios/crear_listas_sinpromo_fast.py
+++ b/Diarios/crear_listas_sinpromo_fast.py
@@ -140,7 +140,8 @@ def procesar_lista(nombre_lista_sql):
 
     models.execute_kw(db, uid, password, "product.pricelist.item", "create", [{
         "pricelist_id": lista_principal_id,
-        "applied_on": "1_product",
+        # Use a global rule so no specific product is required
+        "applied_on": "3_global",
         "min_quantity": 0,
         "compute_price": "fixed",
         "fixed_price": 0.0,


### PR DESCRIPTION
## Summary
- prevent failure when creating a 0 price rule by using a global rule scope

## Testing
- `python -m py_compile Diarios/crear_listas_sinpromo_fast.py`

------
https://chatgpt.com/codex/tasks/task_e_688288c1b4b0832c9ede7cf63cb9eb87