### PR TITLE
Fix redundant commit call

### DIFF
--- a/Diarios/3-actualizar_imagenes_2.py
+++ b/Diarios/3-actualizar_imagenes_2.py
@@ -94,8 +94,6 @@ for i, data in enumerate(productos_raw, 1):
                 )
                 sql_conn.commit()
 
-                sql_conn.commit()
-
                 productos_actualizados += 1
                 print("✅ Imagen actualizada")
             else:


### PR DESCRIPTION
## Summary
- avoid calling `sql_conn.commit()` twice in `3-actualizar_imagenes_2.py`

## Testing
- `python -m py_compile Diarios/3-actualizar_imagenes_2.py`


------
https://chatgpt.com/codex/tasks/task_e_688a6bf6f9f8832cb093d8f6c7e476e2